### PR TITLE
Improve order matching logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.10)
+project(HFT_Simulator)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_library(HFT
+    src/OrderBook.cpp
+    src/MatchingEngine.cpp
+    src/MarketDataFeed.cpp
+)
+
+target_include_directories(HFT PUBLIC src)
+
+add_executable(simulator src/main.cpp)
+target_link_libraries(simulator HFT)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# HFT-Simulator
+# HFT Simulator
+
+This project provides a minimal high-frequency trading simulator. It includes
+an order book, matching engine, market data feed, and a simple example
+strategy. Orders are matched against resting liquidity until either side is
+fully filled so the example better reflects a real exchange.
+
+## Build
+
+```
+mkdir build && cd build
+cmake .. && make
+```
+
+Run with `./simulator`.
+

--- a/src/MarketDataFeed.cpp
+++ b/src/MarketDataFeed.cpp
@@ -1,0 +1,17 @@
+#include "MarketDataFeed.h"
+#include <random>
+
+void MarketDataFeed::setCallback(Callback cb) {
+    callback_ = std::move(cb);
+}
+
+void MarketDataFeed::run(int steps) {
+    std::mt19937 gen{42};
+    std::normal_distribution<> dist{0, 0.1};
+    for (int i = 0; i < steps; ++i) {
+        price_ += dist(gen);
+        MarketTick tick{price_ - 0.01, price_ + 0.01};
+        if (callback_) callback_(tick);
+    }
+}
+

--- a/src/MarketDataFeed.h
+++ b/src/MarketDataFeed.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <functional>
+
+struct MarketTick {
+    double bid;
+    double ask;
+};
+
+class MarketDataFeed {
+public:
+    using Callback = std::function<void(const MarketTick&)>;
+    void setCallback(Callback cb);
+    void run(int steps = 1000);
+private:
+    Callback callback_;
+    double price_{100.0};
+};
+

--- a/src/MatchingEngine.cpp
+++ b/src/MatchingEngine.cpp
@@ -1,0 +1,19 @@
+#include "MatchingEngine.h"
+
+std::vector<Trade> MatchingEngine::processOrder(const Order& order) {
+    std::vector<Trade> trades;
+    Order working = order;
+    auto matched = book_.match(working);
+    for (const auto& m : matched) {
+        Trade t{order.side == Order::Side::Buy ? order.id : m.id,
+                order.side == Order::Side::Sell ? order.id : m.id,
+                m.price,
+                m.quantity};
+        trades.push_back(t);
+    }
+    if (working.quantity > 0) {
+        book_.addOrder(working);
+    }
+    return trades;
+}
+

--- a/src/MatchingEngine.h
+++ b/src/MatchingEngine.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "OrderBook.h"
+#include <vector>
+
+struct Trade {
+    int buyOrderId;
+    int sellOrderId;
+    double price;
+    int quantity;
+};
+
+class MatchingEngine {
+public:
+    std::vector<Trade> processOrder(const Order& order);
+private:
+    OrderBook book_;
+};
+

--- a/src/OrderBook.cpp
+++ b/src/OrderBook.cpp
@@ -1,0 +1,59 @@
+#include "OrderBook.h"
+#include <algorithm>
+
+void OrderBook::addOrder(const Order& order) {
+    if (order.side == Order::Side::Buy) {
+        bids_[order.price].push_back(order);
+    } else {
+        asks_[order.price].push_back(order);
+    }
+}
+
+std::vector<Order> OrderBook::match(Order& incoming) {
+    std::vector<Order> trades;
+    if (incoming.side == Order::Side::Buy) {
+        while (incoming.quantity > 0 && !asks_.empty()) {
+            auto it = asks_.begin();
+            if (incoming.price < it->first) break;
+
+            Order& resting = it->second.front();
+            int execQty = std::min(incoming.quantity, resting.quantity);
+            Order trade = resting;
+            trade.quantity = execQty;
+            trades.push_back(trade);
+
+            resting.quantity -= execQty;
+            incoming.quantity -= execQty;
+
+            if (resting.quantity == 0) {
+                it->second.pop_front();
+            }
+            if (it->second.empty()) {
+                asks_.erase(it);
+            }
+        }
+    } else {
+        while (incoming.quantity > 0 && !bids_.empty()) {
+            auto it = bids_.begin();
+            if (incoming.price > it->first) break;
+
+            Order& resting = it->second.front();
+            int execQty = std::min(incoming.quantity, resting.quantity);
+            Order trade = resting;
+            trade.quantity = execQty;
+            trades.push_back(trade);
+
+            resting.quantity -= execQty;
+            incoming.quantity -= execQty;
+
+            if (resting.quantity == 0) {
+                it->second.pop_front();
+            }
+            if (it->second.empty()) {
+                bids_.erase(it);
+            }
+        }
+    }
+    return trades;
+}
+

--- a/src/OrderBook.h
+++ b/src/OrderBook.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <deque>
+#include <map>
+#include <vector>
+
+struct Order {
+    enum class Side { Buy, Sell };
+    int id;
+    Side side;
+    double price;
+    int quantity;
+};
+
+class OrderBook {
+public:
+    void addOrder(const Order& order);
+    /**
+     * Attempt to match the incoming order against the book. The order's
+     * quantity is reduced by the executed amount so callers can determine
+     * any remaining quantity.
+     */
+    std::vector<Order> match(Order& incoming);
+private:
+    std::map<double, std::deque<Order>, std::greater<double>> bids_;
+    std::map<double, std::deque<Order>> asks_;
+};
+

--- a/src/StrategyInterface.h
+++ b/src/StrategyInterface.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "MarketDataFeed.h"
+#include "MatchingEngine.h"
+#include <vector>
+
+class IStrategy {
+public:
+    virtual ~IStrategy() = default;
+    virtual void onMarketData(const MarketTick&) = 0;
+    virtual std::vector<Order> getOrders() = 0;
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,43 @@
+#include "MarketDataFeed.h"
+#include "MatchingEngine.h"
+#include "StrategyInterface.h"
+#include <iostream>
+#include <memory>
+
+class NaiveStrategy : public IStrategy {
+public:
+    void onMarketData(const MarketTick& tick) override {
+        lastBid_ = tick.bid;
+        lastAsk_ = tick.ask;
+    }
+    std::vector<Order> getOrders() override {
+        std::vector<Order> orders;
+        Order buy{nextId_++, Order::Side::Buy, lastBid_, 1};
+        Order sell{nextId_++, Order::Side::Sell, lastAsk_, 1};
+        orders.push_back(buy);
+        orders.push_back(sell);
+        return orders;
+    }
+private:
+    double lastBid_{0};
+    double lastAsk_{0};
+    int nextId_{1};
+};
+
+int main() {
+    MatchingEngine engine;
+    MarketDataFeed feed;
+    NaiveStrategy strat;
+    feed.setCallback([&](const MarketTick& tick){
+        strat.onMarketData(tick);
+        for (const auto& order : strat.getOrders()) {
+            auto trades = engine.processOrder(order);
+            for (const auto& t : trades) {
+                std::cout << "trade price=" << t.price << " qty=" << t.quantity << "\n";
+            }
+        }
+    });
+    feed.run(100);
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- refine OrderBook::match to handle partial fills
- update MatchingEngine to store remaining order quantity
- document updated behavior in README

## Testing
- `cmake .. && make -j$(nproc)`
- `./simulator | head`

------
https://chatgpt.com/codex/tasks/task_e_68768da6a114833384d16c59ec2f8ce8